### PR TITLE
basic-constructs/functions.rst: fix function type and getelementptr i…

### DIFF
--- a/basic-constructs/functions.rst
+++ b/basic-constructs/functions.rst
@@ -82,11 +82,11 @@ return type once, not twice as you'd have to do if it was a true cast:
 
     declare i32 @printf(i8*, ...) nounwind
 
-    @.text = internal constant [20 x i8] c"Argument count: %d\0A\00"
+    @.textstr = internal constant [20 x i8] c"Argument count: %d\0A\00"
 
     define i32 @main(i32 %argc, i8** %argv) nounwind {
         ; printf("Argument count: %d\n", argc)
-        %1 = call i32 (i8*, ...)* @printf(i8* getelementptr([20 x i8]* @.text, i32 0, i32 0), i32 %argc)
+        %1 = call i32 (i8*, ...) @printf(i8* getelementptr([20 x i8], [20 x i8]* @.textstr, i32 0, i32 0), i32 %argc)
         ret i32 0
     }
 


### PR DESCRIPTION
basic-constructs/functions.rst: fix function type and getelementptr instructions.
My environment information:

* LLVM: 6.0.0
* OS: x86_64-Ubuntu-16.04-xenial' 

Maybe some problems are caused by the version.

The problems lie in this snippet:
```llvm
 %1 = call i32 (i8*, ...)* @printf(i8* getelementptr([20 x i8]* @.text, i32 0, i32 0), i32 %argc)
```

And the problems are:

1. `@.text` has been already used when compiling. I cannot define a variable named `@.text` or I'll get an ERROR `LLVM ERROR: symbol '.text' is already defined`. I don't know why but I think we'd better do some name mangling.
  I change the name from `@.text` to `@.textstr`...

2. The `call` instruction is followed by type of the function, it should be value type not a pointer type.
```llvm 
 call i32 (i8*, ...)* @printf` ->  `call i32 (i8*, ...) @printf
```

3. At `getelementptr`  instruction, the first argument is missing. `getelementptr([20 x i8]* @.textstr, i32 0, i32 0)` -> `getelementptr([20 x i8], [20 x i8]* @.textstr, i32 0, i32 0)`
