### PR TITLE
Fix mistake in classes.rst

### DIFF
--- a/object-oriented-constructs/classes.rst
+++ b/object-oriented-constructs/classes.rst
@@ -51,7 +51,7 @@ We first transform this code into two separate pieces:
     ; The Foo::GetLength() method.
     define i32 @Foo_GetLength(%Foo* %this) nounwind {
         %1 = getelementptr %Foo* %this, i32 0, i32 0
-        %2 = load i32* %this
+        %2 = load i32* %1
         ret i32 %2
     }
 


### PR DESCRIPTION
Foo_GetLength method contained invalid code: instead of loading `%2` from `%1` it loaded from `%this`.