### PR TITLE
Update `getelementptr` and `load` instruction.

### DIFF
--- a/basic-constructs/casts.rst
+++ b/basic-constructs/casts.rst
@@ -49,7 +49,7 @@ Becomes:
     define void @allocate() nounwind {
         %1 = call i8* @malloc(i32 4)
         %foo = bitcast i8* %1 to %Foo*
-        %2 = getelementptr %Foo* %foo, i32 0, i32 0
+        %2 = getelementptr %Foo, %Foo* %foo, i32 0, i32 0
         store i32 12, i32* %2
         call void @free(i8* %1)
         ret void

--- a/basic-constructs/casts.rst
+++ b/basic-constructs/casts.rst
@@ -79,7 +79,7 @@ You use the ``zext`` instruction:
     @word = global i32 0
 
     define void @main() nounwind {
-        %1 = load i8* @byte
+        %1 = load i8, i8* @byte
         %2 = zext i8 %1 to i32
         store i32 %2, i32* @word
         ret void
@@ -98,7 +98,7 @@ section:
     @int  = global i32 0
 
     define void @main() nounwind {
-        %1 = load i8* @char
+        %1 = load i8, i8* @char
         %2 = sext i8 %1 to i32
         store i32 %2, i32* @int
         ret void
@@ -118,7 +118,7 @@ for which reason ``trunc`` is sufficient to handle both cases:
     @char = global i8 0
 
     define void @main() nounwind {
-        %1 = load i32* @int
+        %1 = load i32, i32* @int
         %2 = trunc i32 %1 to i8
         store i8 %2, i8* @char
         ret void
@@ -148,7 +148,7 @@ Becomes:
     @large = global double 0.0
 
     define void @main() nounwind {
-        %1 = load float* @small
+        %1 = load float, float* @small
         %2 = fpext float %1 to double
         store double %2, double* @large
         ret void
@@ -165,7 +165,7 @@ Likewise, a floating point number can be truncated to a smaller size:
     @small = global float 0.0
 
     define void @main() nounwind {
-        %1 = load double* @large
+        %1 = load double, double* @large
         %2 = fptrunc double %1 to float
         store float %2, float* @small
         ret void

--- a/basic-constructs/constants.rst
+++ b/basic-constructs/constants.rst
@@ -39,7 +39,7 @@ with the following little snippet of code:
 .. code-block:: llvm
 
     %Struct = type { i8, i32, i8* }
-    @Struct_size = constant i32 ptrtoint (%Struct* getelementptr (%Struct* null, i32 1)) to i32
+    @Struct_size = constant i32 ptrtoint (%Struct* getelementptr (%Struct, %Struct* null, i32 1) to i32)
 
 ``@Struct_size`` will now contain the size of the structure ``%Struct``.
 The trick is to compute the offset of the second element


### PR DESCRIPTION
In newest LLVM release (8.0), these instructions should be updated. I think I could help updated these instructions in the next week.

PS. I am thinking, what if we create some branches according to LLVM version? For example, codes in branch 6.0, should use instructions in LLVM-6.0.