### PR TITLE
Fix `load`, `getelementptr` instructions, and `@printf()` function call.

### DIFF
--- a/advanced-constructs/listings/listing_5.ll
+++ b/advanced-constructs/listings/listing_5.ll
@@ -5,7 +5,7 @@
 
 define void @foo_setup(%foo_context* %context) nounwind {
 	; set up 'block'
-	%1 = getelementptr %foo_context* %context, i32 0, i32 0
+	%1 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 0
 	store i8* blockaddress(@foo_yield, %.yield1), i8** %1
 
 	ret void
@@ -16,39 +16,39 @@ define void @foo_setup(%foo_context* %context) nounwind {
 ; the iterator again.
 define i1 @foo_yield(%foo_context* %context) nounwind {
 	; dispatch to the active generator block
-	%1 = getelementptr %foo_context* %context, i32 0, i32 0
-	%2 = load i8** %1
+	%1 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 0
+	%2 = load i8*, i8** %1
 	indirectbr i8* %2, [ label %.yield1, label %.yield2, label %.yield3, label %.done ]
 
 .yield1:
 	; store the result value (1)
-	%3 = getelementptr %foo_context* %context, i32 0, i32 1
+	%3 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 1
 	store i32 1, i32* %3
 
 	; make 'block' point to next block to execute
-	%4 = getelementptr %foo_context* %context, i32 0, i32 0
+	%4 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 0
 	store i8* blockaddress(@foo_yield, %.yield2), i8** %4
 
 	ret i1 1
 
 .yield2:
 	; store the result value (2)
-	%5 = getelementptr %foo_context* %context, i32 0, i32 1
+	%5 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 1
 	store i32 2, i32* %5
 
 	; make 'block' point to next block to execute
-	%6 = getelementptr %foo_context* %context, i32 0, i32 0
+	%6 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 0
 	store i8* blockaddress(@foo_yield, %.yield3), i8** %6
 
 	ret i1 1
 
 .yield3:
 	; store the result value (3)
-	%7 = getelementptr %foo_context* %context, i32 0, i32 1
+	%7 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 1
 	store i32 3, i32* %7
 
 	; make 'block' point to next block to execute
-	%8 = getelementptr %foo_context* %context, i32 0, i32 0
+	%8 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 0
 	store i8* blockaddress(@foo_yield, %.done), i8** %8
 
 	ret i1 1
@@ -73,9 +73,9 @@ define void @main() nounwind {
 	br i1 %1, label %.body, label %.tail
 
 .body:
-	%2 = getelementptr %foo_context* %context, i32 0, i32 1
-	%3 = load i32* %2
-	%4 = call i32 (i8*, ...)* @printf(i8* getelementptr([11 x i8]* @.string, i32 0, i32 0), i32 %3)
+	%2 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 1
+	%3 = load i32, i32* %2
+	%4 = call i32 (i8*, ...) @printf(i8* getelementptr([11 x i8], [11 x i8]* @.string, i32 0, i32 0), i32 %3)
 	br label %.head
 
 .tail:

--- a/advanced-constructs/listings/listing_7.ll
+++ b/advanced-constructs/listings/listing_7.ll
@@ -8,15 +8,15 @@
 
 define void @foo_setup(%foo_context* %context, i32 %start, i32 %after) nounwind {
 	; set up 'block'
-	%1 = getelementptr %foo_context* %context, i32 0, i32 0
+	%1 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 0
 	store i8* blockaddress(@foo_yield, %.init), i8** %1
 
 	; set up 'start'
-	%2 = getelementptr %foo_context* %context, i32 0, i32 1
+	%2 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 1
 	store i32 %start, i32* %2
 
 	; set up 'after'
-	%3 = getelementptr %foo_context* %context, i32 0, i32 2
+	%3 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 2
 	store i32 %after, i32* %3
 
 	ret void
@@ -24,24 +24,24 @@ define void @foo_setup(%foo_context* %context, i32 %start, i32 %after) nounwind 
 
 define i1 @foo_yield(%foo_context* %context) nounwind {
 	; dispatch to the active generator block
-	%1 = getelementptr %foo_context* %context, i32 0, i32 0
-	%2 = load i8** %1
+	%1 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 0
+	%2 = load i8*, i8** %1
    indirectbr i8* %2, [ label %.init, label %.loop_close, label %.end ]
 
 .init:
 	; copy argument 'start' to the local variable 'index'
-	%3 = getelementptr %foo_context* %context, i32 0, i32 1
-	%start = load i32* %3
-	%4 = getelementptr %foo_context* %context, i32 0, i32 3
+	%3 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 1
+	%start = load i32, i32* %3
+	%4 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 3
 	store i32 %start, i32* %4
 	br label %.head
 
 .head:
 	; for (; index < after; )
-	%5 = getelementptr %foo_context* %context, i32 0, i32 3
-	%index = load i32* %5
-	%6 = getelementptr %foo_context* %context, i32 0, i32 2
-	%after = load i32* %6
+	%5 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 3
+	%index = load i32, i32* %5
+	%6 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 2
+	%after = load i32, i32* %6
 	%again = icmp slt i32 %index, %after
 	br i1 %again, label %.loop_begin, label %.exit
 
@@ -53,11 +53,11 @@ define i1 @foo_yield(%foo_context* %context) nounwind {
 .even:
 	; store 'index + 1' in 'value'
 	%9 = add i32 %index, 1
-	%10 = getelementptr %foo_context* %context, i32 0, i32 4
+	%10 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 4
 	store i32 %9, i32* %10
 
 	; make 'block' point to the end of the loop (after the yield)
-	%11 = getelementptr %foo_context* %context, i32 0, i32 0
+	%11 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 0
 	store i8* blockaddress(@foo_yield, %.loop_close), i8** %11
 
 	ret i1 1
@@ -65,26 +65,26 @@ define i1 @foo_yield(%foo_context* %context) nounwind {
 .odd:
 	; store 'index - 1' in value
 	%12 = sub i32 %index, 1
-	%13 = getelementptr %foo_context* %context, i32 0, i32 4
+	%13 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 4
 	store i32 %12, i32* %13
 
 	; make 'block' point to the end of the loop (after the yield)
-	%14 = getelementptr %foo_context* %context, i32 0, i32 0
+	%14 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 0
 	store i8* blockaddress(@foo_yield, %.loop_close), i8** %14
 
 	ret i1 1
 
 .loop_close:
 	; increment 'index'
-	%15 = getelementptr %foo_context* %context, i32 0, i32 3
-	%16 = load i32* %15
+	%15 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 3
+	%16 = load i32, i32* %15
 	%17 = add i32 %16, 1
 	store i32 %17, i32* %15
 	br label %.head
 
 .exit:
 	; make 'block' point to the %.end label
-	%x = getelementptr %foo_context* %context, i32 0, i32 0
+	%x = getelementptr %foo_context, %foo_context* %context, i32 0, i32 0
 	store i8* blockaddress(@foo_yield, %.end), i8** %x
 	br label %.end
 
@@ -108,9 +108,9 @@ define i32 @main() nounwind {
 	br i1 %1, label %.body, label %.tail
 
 .body:
-	%2 = getelementptr %foo_context* %context, i32 0, i32 4
-	%3 = load i32* %2
-	%4 = call i32 (i8*, ...)* @printf(i8* getelementptr([11 x i8]* @.string, i32 0, i32 0), i32 %3)
+	%2 = getelementptr %foo_context, %foo_context* %context, i32 0, i32 4
+	%3 = load i32, i32* %2
+	%4 = call i32 (i8*, ...) @printf(i8* getelementptr([11 x i8], [11 x i8]* @.string, i32 0, i32 0), i32 %3)
 	br label %.head
 
 .tail:

--- a/exception-handling/listings/propagated_return_values.ll
+++ b/exception-handling/listings/propagated_return_values.ll
@@ -17,7 +17,7 @@ declare i32 @puts(i8* noalias nocapture) nounwind
 
 @.Object_vtable = private constant %Object_vtable_type {
 	%Object_vtable_type* null,    ; This is the root object of the object hierarchy
-	i8* getelementptr([7 x i8]* @.Object_class_name, i32 0, i32 0)
+	i8* getelementptr([7 x i8], [7 x i8]* @.Object_class_name, i32 0, i32 0)
 }
 
 %Object = type {
@@ -34,21 +34,21 @@ define i1 @Object_IsA(%Object* %object, i8* %name) nounwind {
 	br i1 %0, label %.once, label %.exit_false
 
 .once:
-	%1 = getelementptr %Object* %object, i32 0, i32 0
+	%1 = getelementptr %Object, %Object* %object, i32 0, i32 0
 	br label %.body
 
 .body:
 	; if (vtable->class == name)
 	%2 = phi %Object_vtable_type** [ %1, %.once ], [ %7, %.next]
-	%3 = load %Object_vtable_type** %2
-	%4 = getelementptr %Object_vtable_type* %3, i32 0, i32 1
-	%5 = load i8** %4
+	%3 = load %Object_vtable_type*, %Object_vtable_type** %2
+	%4 = getelementptr %Object_vtable_type, %Object_vtable_type* %3, i32 0, i32 1
+	%5 = load i8*, i8** %4
 	%6 = icmp eq i8* %5, %name
 	br i1 %6, label %.exit_true, label %.next
 
 .next:
 	; object = object->above
-	%7 = getelementptr %Object_vtable_type* %3, i32 0, i32 0
+	%7 = getelementptr %Object_vtable_type, %Object_vtable_type* %3, i32 0, i32 0
 
 	; while (object != null)
 	%8 = icmp ne %Object_vtable_type* %3, null
@@ -73,7 +73,7 @@ define i1 @Object_IsA(%Object* %object, i8* %name) nounwind {
 
 @.Exception_vtable = private constant %Exception_vtable_type {
 	%Object_vtable_type* @.Object_vtable,        ; the parent of this class is the Object class
-	i8* getelementptr([10 x i8]* @.Exception_class_name, i32 0, i32 0)
+	i8* getelementptr([10 x i8], [10 x i8]* @.Exception_class_name, i32 0, i32 0)
 }
 
 %Exception = type {
@@ -83,19 +83,19 @@ define i1 @Object_IsA(%Object* %object, i8* %name) nounwind {
 
 define void @Exception_Create_String(%Exception* %this, i8* %text) nounwind {
 	; set up vtable
-	%1 = getelementptr %Exception* %this, i32 0, i32 0
+	%1 = getelementptr %Exception, %Exception* %this, i32 0, i32 0
 	store %Exception_vtable_type* @.Exception_vtable, %Exception_vtable_type** %1
 
 	; save input text string into _text
-	%2 = getelementptr %Exception* %this, i32 0, i32 1
+	%2 = getelementptr %Exception, %Exception* %this, i32 0, i32 1
 	store i8* %text, i8** %2
 
 	ret void
 }
 
 define i8* @Exception_GetText(%Exception* %this) nounwind {
-	%1 = getelementptr %Exception* %this, i32 0, i32 1
-	%2 = load i8** %1
+	%1 = getelementptr %Exception, %Exception* %this, i32 0, i32 1
+	%2 = load i8*, i8** %1
 	ret i8* %2
 }
 
@@ -104,19 +104,19 @@ define i8* @Exception_GetText(%Exception* %this) nounwind {
 %Foo = type { i32 }
 
 define void @Foo_Create_Default(%Foo* %this) nounwind {
-	%1 = getelementptr %Foo* %this, i32 0, i32 0
+	%1 = getelementptr %Foo, %Foo* %this, i32 0, i32 0
 	store i32 0, i32* %1
 	ret void
 }
 
 define i32 @Foo_GetLength(%Foo* %this) nounwind {
-	%1 = getelementptr %Foo* %this, i32 0, i32 0
-	%2 = load i32* %1
+	%1 = getelementptr %Foo, %Foo* %this, i32 0, i32 0
+	%2 = load i32, i32* %1
 	ret i32 %2
 }
 
 define void @Foo_SetLength(%Foo* %this, i32 %value) nounwind {
-	%1 = getelementptr %Foo* %this, i32 0, i32 0
+	%1 = getelementptr %Foo, %Foo* %this, i32 0, i32 0
 	store i32 %value, i32* %1
 	ret void
 }
@@ -140,7 +140,7 @@ define %Exception* @Bar(i1 %fail, i32* %result) nounwind {
 	; throw new Exception(...)
 	%2 = call i8* @malloc(i32 8)
 	%3 = bitcast i8* %2 to %Exception*
-	%4 = getelementptr [30 x i8]* @.message1, i32 0, i32 0
+	%4 = getelementptr [30 x i8], [30 x i8]* @.message1, i32 0, i32 0
 	call void @Exception_Create_String(%Exception* %3, i8* %4)
 	ret %Exception* %3
 
@@ -173,18 +173,18 @@ define i32 @main(i32 %argc, i8** %argv) nounwind {
 
 .catch_block:
 	%4 = bitcast %Exception* %2 to %Object*
-	%5 = getelementptr [10 x i8]* @.Exception_class_name, i32 0, i32 0
+	%5 = getelementptr [10 x i8], [10 x i8]* @.Exception_class_name, i32 0, i32 0
 	%6 = call i1 @Object_IsA(%Object* %4, i8* %5)
 	br i1 %6, label %.catch_exception, label %.catch_all
 
 .catch_exception:
-	%7 = getelementptr [11 x i8]* @.message2, i32 0, i32 0
+	%7 = getelementptr [11 x i8], [11 x i8]* @.message2, i32 0, i32 0
 	%8 = call i8* @Exception_GetText(%Exception* %2)
-	%9 = call i32 (i8*, ...)* @printf(i8* %7, i8* %8)
+	%9 = call i32 (i8*, ...) @printf(i8* %7, i8* %8)
 	br label %.exit
 
 .catch_all:
-	%10 = getelementptr [44 x i8]* @.message3, i32 0, i32 0
+	%10 = getelementptr [44 x i8], [44 x i8]* @.message3, i32 0, i32 0
 	%11 = call i32 @puts(i8* %10)
 	br label %.exit
 

--- a/object-oriented-constructs/boxing-and-unboxing.rst
+++ b/object-oriented-constructs/boxing-and-unboxing.rst
@@ -20,20 +20,20 @@ both steps:
 
     define void @Integer_Create(%Integer* %this, i32 %value) nounwind {
         ; you might set up a vtable and associated virtual methods here
-        %1 = getelementptr %Integer* %this, i32 0, i32 0
+        %1 = getelementptr %Integer, %Integer* %this, i32 0, i32 0
         store i32 %value, i32* %1
         ret void
     }
 
     define i32 @Integer_GetValue(%Integer* %this) nounwind {
-        %1 = getelementptr %Integer* %this, i32 0, i32 0
-        %2 = load i32* %1
+        %1 = getelementptr %Integer, %Integer* %this, i32 0, i32 0
+        %2 = load i32, i32* %1
         ret i32 %2
     }
 
     define i32 @main() nounwind {
         ; box @Boxee in an instance of %Integer
-        %1 = load i32* @Boxee
+        %1 = load i32, i32* @Boxee
         %2 = alloca %Integer
         call void @Integer_Create(%Integer* %2, i32 %1)
 

--- a/object-oriented-constructs/classes.rst
+++ b/object-oriented-constructs/classes.rst
@@ -43,21 +43,21 @@ We first transform this code into two separate pieces:
 
     ; The default constructor for class Foo.
     define void @Foo_Create_Default(%Foo* %this) nounwind {
-        %1 = getelementptr %Foo* %this, i32 0, i32 0
+        %1 = getelementptr %Foo, %Foo* %this, i32 0, i32 0
         store i32 0, i32* %1
         ret void
     }
 
     ; The Foo::GetLength() method.
     define i32 @Foo_GetLength(%Foo* %this) nounwind {
-        %1 = getelementptr %Foo* %this, i32 0, i32 0
-        %2 = load i32* %1
+        %1 = getelementptr %Foo, %Foo* %this, i32 0, i32 0
+        %2 = load i32, i32* %1
         ret i32 %2
     }
 
     ; The Foo::SetLength() method.
     define void @Foo_SetLength(%Foo* %this, i32 %value) nounwind {
-        %1 = getelementptr %Foo* %this, i32 0, i32 0
+        %1 = getelementptr %Foo, %Foo* %this, i32 0, i32 0
         store i32 %value, i32* %1
         ret void
     }

--- a/object-oriented-constructs/multiple-inheritance.rst
+++ b/object-oriented-constructs/multiple-inheritance.rst
@@ -56,7 +56,7 @@ This is equivalent to the following LLVM IR:
     }
 
     define void @BaseA_SetA(%BaseA* %this, i32 %value) nounwind {
-        %1 = getelementptr %BaseA* %this, i32 0, i32 0
+        %1 = getelementptr %BaseA, %BaseA* %this, i32 0, i32 0
         store i32 %value, i32* %1
         ret void
     }
@@ -69,7 +69,7 @@ This is equivalent to the following LLVM IR:
     define void @BaseB_SetB(%BaseB* %this, i32 %value) nounwind {
         %1 = bitcast %BaseB* %this to %BaseA*
         call void @BaseA_SetA(%BaseA* %1, i32 %value)
-        %2 = getelementptr %BaseB* %this, i32 0, i32 1
+        %2 = getelementptr %BaseB, %BaseB* %this, i32 0, i32 1
         store i32 %value, i32* %2
         ret void
     }
@@ -83,7 +83,7 @@ This is equivalent to the following LLVM IR:
     define void @Derived_SetC(%Derived* %this, i32 %value) nounwind {
         %1 = bitcast %Derived* %this to %BaseB*
         call void @BaseB_SetB(%BaseB* %1, i32 %value)
-        %2 = getelementptr %Derived* %this, i32 0, i32 2
+        %2 = getelementptr %Derived, %Derived* %this, i32 0, i32 2
         store i32 %value, i32* %2
         ret void
     }

--- a/object-oriented-constructs/single-inheritance.rst
+++ b/object-oriented-constructs/single-inheritance.rst
@@ -43,7 +43,7 @@ declaring a the base class as a first member in the inheriting class:
     }
 
     define void @Base_SetA(%Base* %this, i32 %value) nounwind {
-        %1 = getelementptr %Base* %this, i32 0, i32 0
+        %1 = getelementptr %Base, %Base* %this, i32 0, i32 0
         store i32 %value, i32* %1
         ret void
     }
@@ -56,7 +56,7 @@ declaring a the base class as a first member in the inheriting class:
     define void @Derived_SetB(%Derived* %this, i32 %value) nounwind {
         %1 = bitcast %Derived* %this to %Base*
         call void @Base_SetA(%Base* %1, i32 %value)
-        %2 = getelementptr %Derived* %this, i32 0, i32 1
+        %2 = getelementptr %Derived, %Derived* %this, i32 0, i32 1
         store i32 %value, i32* %2
         ret void
     }

--- a/object-oriented-constructs/the-new-operator.rst
+++ b/object-oriented-constructs/the-new-operator.rst
@@ -18,7 +18,7 @@ All calls of the form ``new X`` are mapped into:
     %X = type { i8 }
 
     define void @X_Create_Default(%X* %this) nounwind {
-        %1 = getelementptr %X* %this, i32 0, i32 0
+        %1 = getelementptr %X, %X* %this, i32 0, i32 0
         store i8 0, i8* %1
         ret void
     }
@@ -47,7 +47,7 @@ in turn:
     %X = type { i32 }
 
     define void @X_Create_Default(%X* %this) nounwind {
-        %1 = getelementptr %X* %this, i32 0, i32 0
+        %1 = getelementptr %X, %X* %this, i32 0, i32 0
         store i32 0, i32* %1
         ret void
     }
@@ -59,24 +59,24 @@ in turn:
         %i = alloca i32                  ; %i = ptr to the loop index into the array
         store i32 0, i32* %i
 
-        %1 = load i32* %n                ; %1 = *%n
+        %1 = load i32, i32* %n           ; %1 = *%n
         %2 = mul i32 %1, 4               ; %2 = %1 * sizeof(X)
         %3 = call i8* @malloc(i32 %2)    ; %3 = malloc(100 * sizeof(X))
         %4 = bitcast i8* %3 to %X*       ; %4 = (X*) %3
         br label %.loop_head
 
     .loop_head:                         ; for (; %i < %n; %i++)
-        %5 = load i32* %i
-        %6 = load i32* %n
+        %5 = load i32, i32* %i
+        %6 = load i32, i32* %n
         %7 = icmp slt i32 %5, %6
         br i1 %7, label %.loop_body, label %.loop_tail
 
     .loop_body:
-        %8 = getelementptr %X* %4, i32 %5
+        %8 = getelementptr %X, %X* %4, i32 %5
         call void @X_Create_Default(%X* %8)
 
         %9 = add i32 %5, 1
-        store i32 %9 i32* %i
+        store i32 %9, i32* %i
 
         br label %.loop_head
 

--- a/object-oriented-constructs/virtual-methods.rst
+++ b/object-oriented-constructs/virtual-methods.rst
@@ -40,8 +40,8 @@ This becomes:
     %Foo = type { %Foo_vtable_type*, i32 }
 
     define i32 @Foo_GetLengthTimesTwo(%Foo* %this) nounwind {
-        %1 = getelementptr %Foo* %this, i32 0, i32 1
-        %2 = load i32* %1
+        %1 = getelementptr %Foo, %Foo* %this, i32 0, i32 1
+        %2 = load i32, i32* %1
         %3 = mul i32 %2, 2
         ret i32 %3
     }
@@ -51,15 +51,15 @@ This becomes:
     }
 
     define void @Foo_Create_Default(%Foo* %this) nounwind {
-        %1 = getelementptr %Foo* %this, i32 0, i32 0
+        %1 = getelementptr %Foo, %Foo* %this, i32 0, i32 0
         store %Foo_vtable_type* @Foo_vtable_data, %Foo_vtable_type** %1
-        %2 = getelementptr %Foo* %this, i32 0, i32 1
+        %2 = getelementptr %Foo, %Foo* %this, i32 0, i32 1
         store i32 0, i32* %2
         ret void
     }
 
     define void @Foo_SetLength(%Foo* %this, i32 %value) nounwind {
-        %1 = getelementptr %Foo* %this, i32 0, i32 1
+        %1 = getelementptr %Foo, %Foo* %this, i32 0, i32 1
         store i32 %value, i32* %1
         ret void
     }
@@ -68,10 +68,10 @@ This becomes:
         %foo = alloca %Foo
         call void @Foo_Create_Default(%Foo* %foo)
         call void @Foo_SetLength(%Foo* %foo, i32 4)
-        %1 = getelementptr %Foo* %foo, i32 0, i32 0
-        %2 = load %Foo_vtable_type** %1
-        %3 = getelementptr %Foo_vtable_type* %2, i32 0, i32 0
-        %4 = load i32(%Foo*)** %3
+        %1 = getelementptr %Foo, %Foo* %foo, i32 0, i32 0
+        %2 = load %Foo_vtable_type*, %Foo_vtable_type** %1
+        %3 = getelementptr %Foo_vtable_type, %Foo_vtable_type* %2, i32 0, i32 0
+        %4 = load i32(%Foo*)*, i32(%Foo*)** %3
         %5 = call i32 %4(%Foo* %foo)
         ret i32 %5
     }


### PR DESCRIPTION
Almost done!

#### TODO:

- Code example for `Setjmp/Longjmp Exception Handling` will cause my interpreter crash, I will fix it as soon as possible.
- Code examples for `Interfacing to Operating Systems` have to be checked.