### PR TITLE
Specified default language (EN) for Sphinx to silence warning.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -28,7 +28,7 @@ release = ''
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Sphinx complains that no default language is given so I gave it one (EN for English).