### PR TITLE
Changed 'sphinx-build-3' into 'sphinx-build' as the former is gone.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = 
-SPHINXBUILD   = sphinx-build-3
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = MappingHighLevelConstructstoLLVMIR
 SOURCEDIR     = .
 BUILDDIR      = _build


### PR DESCRIPTION
Set up a new Ubuntu Server 23.04 x64 box and there's no `sphinx-build-3` anymore, so I changed it to `sphinx-build`.