### PR TITLE
Fix pointer comparison in propagated_return_values.ll

### DIFF
--- a/exception-handling/listings/propagated_return_values.ll
+++ b/exception-handling/listings/propagated_return_values.ll
@@ -51,7 +51,7 @@ define i1 @Object_IsA(%Object* %object, i8* %name) nounwind {
 	%7 = getelementptr %Object_vtable_type, %Object_vtable_type* %3, i32 0, i32 0
 
 	; while (object != null)
-	%8 = icmp ne %Object_vtable_type* %3, null
+	%8 = icmp ne %Object_vtable_type* %7, null
 	br i1 %8, label %.body, label %.exit_false
 
 .exit_true:


### PR DESCRIPTION
The previous version uses the wrong pointer to do null check.

This change fixes the null check using the recently created local variable `%7`.